### PR TITLE
Fixed: Missing Domain name for fixez.com entry

### DIFF
--- a/offenders.csv
+++ b/offenders.csv
@@ -5092,7 +5092,7 @@ prepaway.com,http://plaintextoffenders.com/post/174146626986/prepawaycom-certifi
 getintoivy.com,http://plaintextoffenders.com/post/174241373796/getintoivycom-college-acceptance-guide
 calibro.com,http://plaintextoffenders.com/post/174430227901/calibrocom-books-retailer
 britcar.com,http://plaintextoffenders.com/post/174289868006/britcarcom-brit-carcouk-car-parts-retailer-a
-,http://plaintextoffenders.com/post/173989398598/fixezcom-mobile-repair-parts-retailer-fixezcom
+fixez.com,http://plaintextoffenders.com/post/173989398598/fixezcom-mobile-repair-parts-retailer-fixezcom
 alfasent.com,http://plaintextoffenders.com/post/174114040683/alfasentcom-package-forwarding-british-forward
 geocities.ws,http://plaintextoffenders.com/post/174044421432/geocitiesws-web-hosting-yahoo-geocities-site
 swizznet.com,http://plaintextoffenders.com/post/174322994063/swizznetcom-hosted-accounting-solutions-swizznet


### PR DESCRIPTION
"fixez.com,http://plaintextoffenders.com/post/173989398598/fixezcom-mobile-repair-parts-retailer-fixezcom"
Was missing the Domain name in the CSV